### PR TITLE
fix: keep IPQualityScore API keys out of URLs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2021-2025 IPQualityScore.com
+   Copyright (c) 2021-2026 IPQualityScore.com
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: IPQualityScore
-Copyright (c) 2021-2025 IPQualityScore.com
+Copyright (c) 2021-2026 IPQualityScore.com
 Third Party Software Attributions:
 
 @@@@============================================================================

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # IPQualityScore
 
-Publisher: IPQualityScore \
-Connector Version: 1.2.1 \
-Product Vendor: IPQualityScore \
-Product Name: IPQualityScore \
+Publisher: IPQualityScore <br>
+Connector Version: 1.2.1 <br>
+Product Vendor: IPQualityScore <br>
+Product Name: IPQualityScore <br>
 Minimum Product Version: 6.3.0
 
 This app implements IP, URL and Email investigative capabilities utilizing IPQualityScore
@@ -18,18 +18,18 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validates the connectivity by querying IPQualityScore \
-[email validation](#action-email-validation) - Queries IPQualityScore's Email Validation API \
-[url checker](#action-url-checker) - Queries IPQualityScore's malicious URL scanner API \
-[ip reputation](#action-ip-reputation) - Queries IPQualityScore's Proxy and VPN detection API \
-[phone validation](#action-phone-validation) - Queries IPQualityScore's Phone Validation API \
+[test connectivity](#action-test-connectivity) - Validates the connectivity by querying IPQualityScore <br>
+[email validation](#action-email-validation) - Queries IPQualityScore's Email Validation API <br>
+[url checker](#action-url-checker) - Queries IPQualityScore's malicious URL scanner API <br>
+[ip reputation](#action-ip-reputation) - Queries IPQualityScore's Proxy and VPN detection API <br>
+[phone validation](#action-phone-validation) - Queries IPQualityScore's Phone Validation API <br>
 [dark web leak](#action-dark-web-leak) - Queries IPQualityScore's Dark Web Leak API
 
 ## action: 'test connectivity'
 
 Validates the connectivity by querying IPQualityScore
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -44,7 +44,7 @@ No Output
 
 Queries IPQualityScore's Email Validation API
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 If email information is unavailable in IPQualityScore, only 'email' and 'message' property would be populated. The 'strictness' is an optional parameter to perform (higher number) or ignore (lower number) of additional intelligence checks. The possible values for 'strictness' are 0,1 and 2.
@@ -104,7 +104,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Queries IPQualityScore's malicious URL scanner API
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 If URL information is unavailable in IPQualityScore, only 'url' and 'in_database' property would be populated. The 'strictness' is an optional parameter to perform (higher number) or ignore (lower number) of additional intelligence checks. The possible values for 'strictness' are 0,1 and 2.
@@ -133,7 +133,7 @@ summary.total_objects_successful | numeric | | |
 
 Queries IPQualityScore's Proxy and VPN detection API
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 If URL information is unavailable in IPQualityScore, only 'message' and 'status_code' properties would be populated. The 'strictness' is an optional parameter to perform (higher number) or ignore (lower number) of additional intelligence checks. The possible values for 'strictness' are 0,1 and 2.
@@ -204,7 +204,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Queries IPQualityScore's Phone Validation API
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 The IPQS Phone Number Validation API enables you to quickly analyze phone numbers to verify their risk score, country of origin, carrier, validity, owner information, and line connection status. This enables you to verify users, improve chargeback defense, and detect fraudulent activity in real-time. The IPQS Phone Number Validation API can research landline and cellular numbers in over 150 countries to identify invalid phone numbers or malicious users.
@@ -266,7 +266,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Queries IPQualityScore's Dark Web Leak API
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 Use the leaked data API to search through a wide collection of breached, stolen, and leaked databases from popular websites that have recently suffered data breaches. Look up email addresses, phone numbers, usernames, or passwords. Perform on-demand leaked data searches using our dark web data API.
@@ -301,7 +301,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2021-2025 IPQualityScore.com
+# Copyright (c) 2021-2026 IPQualityScore.com
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ipqualityscore.json
+++ b/ipqualityscore.json
@@ -13,7 +13,7 @@
     "product_name": "IPQualityScore",
     "product_version_regex": ".*",
     "min_phantom_version": "6.3.0",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": false,
     "latest_tested_versions": [
         "Cloud, API: ipqualityscore.com, February 25 2021"

--- a/ipqualityscore.json
+++ b/ipqualityscore.json
@@ -5,7 +5,7 @@
     "publisher": "IPQualityScore",
     "package_name": "phantom_ipqualityscore",
     "type": "investigative",
-    "license": "Copyright (c) 2021-2025 IPQualityScore.com",
+    "license": "Copyright (c) 2021-2026 IPQualityScore.com",
     "main_module": "ipqualityscore_connector.py",
     "app_version": "1.2.1",
     "utctime_updated": "2025-04-28T20:52:54.698884Z",

--- a/ipqualityscore_connector.py
+++ b/ipqualityscore_connector.py
@@ -118,11 +118,9 @@ class IpqualityscoreConnector(BaseConnector):
         return phantom.APP_SUCCESS, parameter
 
     def test_asset_connectivity(self):
-        config = self.get_config()
-        app_key = config["apikey"]
         self.save_progress(IPQUALITYSCORE_MESSAGE_CONNECTIVITY)
         try:
-            response = requests.get(IPQUALITYSCORE_API_TEST.format(apikey=app_key))  # nosemgrep
+            response = requests.get(IPQUALITYSCORE_API_TEST, headers=self._get_auth_headers())  # nosemgrep
             # python.requests.best-practice.use-timeout.use-timeout
         except Exception as e:
             err = self._get_error_message_from_exception(e)
@@ -157,18 +155,20 @@ class IpqualityscoreConnector(BaseConnector):
         self.save_progress(IPQUALITYSCORE_ERROR_CONNECTIVITY_TEST)
         return self.set_status(phantom.APP_ERROR)
 
-    def create_req_url(self, urltype, param, app_key):
+    def _get_auth_headers(self):
+        return {"IPQS-KEY": self.get_config()["apikey"]}
+
+    def create_req_url(self, urltype, param):
         if urltype == "url":
-            req_url = IPQUALITYSCORE_API_URL_CHECKER.format(apikey=app_key, url=urllib.parse.quote_plus(param["url"]))
+            req_url = IPQUALITYSCORE_API_URL_CHECKER.format(url=urllib.parse.quote_plus(param["url"]))
         elif urltype == "ip":
-            req_url = IPQUALITYSCORE_API_IP_REPUTATION.format(apikey=app_key, ip=param["ip"])
+            req_url = IPQUALITYSCORE_API_IP_REPUTATION.format(ip=param["ip"])
         elif urltype == "email":
-            req_url = IPQUALITYSCORE_API_EMAIL_VALIDATION.format(apikey=app_key, email=param["email"])
+            req_url = IPQUALITYSCORE_API_EMAIL_VALIDATION.format(email=param["email"])
         elif urltype == "phone":
-            req_url = IPQUALITYSCORE_API_PHONE_VALIDATION.format(apikey=app_key, phone=param["phone"])
+            req_url = IPQUALITYSCORE_API_PHONE_VALIDATION.format(phone=param["phone"])
         elif urltype == "darkwebleak":
             req_url = IPQUALITYSCORE_API_DARKWEBLEAK.format(
-                apikey=app_key,
                 type=param["type"],
                 data=urllib.parse.quote_plus(param["value"]),
             )
@@ -192,12 +192,9 @@ class IpqualityscoreConnector(BaseConnector):
         query_string = "&".join(f"{k}={v}" for k, v in optional_params.items() if v is not None)
         if query_string:
             req_url = f"{req_url}?{query_string}"
-        self.debug_print(f"req_url {req_url}")
         return req_url
 
     def check_url(self, param):
-        config = self.get_config()
-        app_key = config["apikey"]
         action_result = self.add_action_result(ActionResult(dict(param)))
         summary = action_result.update_summary({})
 
@@ -207,8 +204,8 @@ class IpqualityscoreConnector(BaseConnector):
 
         self.save_progress(IPQUALITYSCORE_MESSAGE_QUERY_URL, query_url=param["url"])
         try:
-            req_url = self.create_req_url("url", param, app_key)
-            query_res = requests.get(req_url)  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
+            req_url = self.create_req_url("url", param)
+            query_res = requests.get(req_url, headers=self._get_auth_headers())  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
         except Exception as e:
             err = self._get_error_message_from_exception(e)
             self.debug_print(f"check_url: {err}")
@@ -263,8 +260,6 @@ class IpqualityscoreConnector(BaseConnector):
         return action_result.set_status(phantom.APP_SUCCESS)
 
     def ip_reputation(self, param):
-        config = self.get_config()
-        app_key = config["apikey"]
         action_result = self.add_action_result(ActionResult(dict(param)))
         summary = action_result.update_summary({})
 
@@ -282,8 +277,8 @@ class IpqualityscoreConnector(BaseConnector):
 
         self.save_progress(IPQUALITYSCORE_MESSAGE_QUERY_URL, query_ip=param["ip"])
         try:
-            req_url = self.create_req_url("ip", param, app_key)
-            query_res = requests.get(req_url)  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
+            req_url = self.create_req_url("ip", param)
+            query_res = requests.get(req_url, headers=self._get_auth_headers())  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
         except Exception as e:
             err = self._get_error_message_from_exception(e)
             self.debug_print(f"ip_reputation: {err}")
@@ -334,8 +329,6 @@ class IpqualityscoreConnector(BaseConnector):
         return action_result.set_status(phantom.APP_SUCCESS)
 
     def email_validation(self, param):
-        config = self.get_config()
-        app_key = config["apikey"]
         action_result = self.add_action_result(ActionResult(dict(param)))
         summary = action_result.update_summary({})
 
@@ -353,8 +346,8 @@ class IpqualityscoreConnector(BaseConnector):
 
         self.save_progress(IPQUALITYSCORE_MESSAGE_QUERY_URL, query_ip=param["email"])
         try:
-            req_url = self.create_req_url("email", param, app_key)
-            query_res = requests.get(req_url)  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
+            req_url = self.create_req_url("email", param)
+            query_res = requests.get(req_url, headers=self._get_auth_headers())  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
         except Exception as e:
             err = self._get_error_message_from_exception(e)
             self.debug_print(f"ip_reputation: {err}")
@@ -402,8 +395,6 @@ class IpqualityscoreConnector(BaseConnector):
         return action_result.set_status(phantom.APP_SUCCESS)
 
     def phone_validation(self, param):
-        config = self.get_config()
-        app_key = config["apikey"]
         action_result = self.add_action_result(ActionResult(dict(param)))
         summary = action_result.update_summary({})
 
@@ -413,8 +404,8 @@ class IpqualityscoreConnector(BaseConnector):
 
         self.save_progress(IPQUALITYSCORE_MESSAGE_QUERY_URL, query_ip=param["phone"])
         try:
-            req_url = self.create_req_url("phone", param, app_key)
-            query_res = requests.get(req_url)  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
+            req_url = self.create_req_url("phone", param)
+            query_res = requests.get(req_url, headers=self._get_auth_headers())  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
         except Exception as e:
             err = self._get_error_message_from_exception(e)
             self.debug_print(f"phone_validation: {err}")
@@ -462,8 +453,6 @@ class IpqualityscoreConnector(BaseConnector):
         return action_result.set_status(phantom.APP_SUCCESS)
 
     def darkwebleak(self, param):
-        config = self.get_config()
-        app_key = config["apikey"]
         action_result = self.add_action_result(ActionResult(dict(param)))
         summary = action_result.update_summary({})
 
@@ -474,8 +463,8 @@ class IpqualityscoreConnector(BaseConnector):
 
         self.save_progress(IPQUALITYSCORE_MESSAGE_QUERY_URL, query_ip=param["type"])
         try:
-            req_url = self.create_req_url("darkwebleak", param, app_key)
-            query_res = requests.get(req_url)  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
+            req_url = self.create_req_url("darkwebleak", param)
+            query_res = requests.get(req_url, headers=self._get_auth_headers())  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
         except Exception as e:
             err = self._get_error_message_from_exception(e)
             self.debug_print(f"darkwebleak_api: {err}")

--- a/ipqualityscore_connector.py
+++ b/ipqualityscore_connector.py
@@ -1,6 +1,6 @@
 # File: ipqualityscore_connector.py
 #
-# Copyright (c) 2021-2025 IPQualityScore.com
+# Copyright (c) 2021-2026 IPQualityScore.com
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -205,7 +205,9 @@ class IpqualityscoreConnector(BaseConnector):
         self.save_progress(IPQUALITYSCORE_MESSAGE_QUERY_URL, query_url=param["url"])
         try:
             req_url = self.create_req_url("url", param)
-            query_res = requests.get(req_url, headers=self._get_auth_headers())  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
+            query_res = requests.get(
+                req_url, headers=self._get_auth_headers()
+            )  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
         except Exception as e:
             err = self._get_error_message_from_exception(e)
             self.debug_print(f"check_url: {err}")
@@ -278,7 +280,9 @@ class IpqualityscoreConnector(BaseConnector):
         self.save_progress(IPQUALITYSCORE_MESSAGE_QUERY_URL, query_ip=param["ip"])
         try:
             req_url = self.create_req_url("ip", param)
-            query_res = requests.get(req_url, headers=self._get_auth_headers())  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
+            query_res = requests.get(
+                req_url, headers=self._get_auth_headers()
+            )  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
         except Exception as e:
             err = self._get_error_message_from_exception(e)
             self.debug_print(f"ip_reputation: {err}")
@@ -347,7 +351,9 @@ class IpqualityscoreConnector(BaseConnector):
         self.save_progress(IPQUALITYSCORE_MESSAGE_QUERY_URL, query_ip=param["email"])
         try:
             req_url = self.create_req_url("email", param)
-            query_res = requests.get(req_url, headers=self._get_auth_headers())  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
+            query_res = requests.get(
+                req_url, headers=self._get_auth_headers()
+            )  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
         except Exception as e:
             err = self._get_error_message_from_exception(e)
             self.debug_print(f"ip_reputation: {err}")
@@ -405,7 +411,9 @@ class IpqualityscoreConnector(BaseConnector):
         self.save_progress(IPQUALITYSCORE_MESSAGE_QUERY_URL, query_ip=param["phone"])
         try:
             req_url = self.create_req_url("phone", param)
-            query_res = requests.get(req_url, headers=self._get_auth_headers())  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
+            query_res = requests.get(
+                req_url, headers=self._get_auth_headers()
+            )  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
         except Exception as e:
             err = self._get_error_message_from_exception(e)
             self.debug_print(f"phone_validation: {err}")
@@ -464,7 +472,9 @@ class IpqualityscoreConnector(BaseConnector):
         self.save_progress(IPQUALITYSCORE_MESSAGE_QUERY_URL, query_ip=param["type"])
         try:
             req_url = self.create_req_url("darkwebleak", param)
-            query_res = requests.get(req_url, headers=self._get_auth_headers())  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
+            query_res = requests.get(
+                req_url, headers=self._get_auth_headers()
+            )  # nosemgrep: python.requests.best-practice.use-timeout.use-timeout
         except Exception as e:
             err = self._get_error_message_from_exception(e)
             self.debug_print(f"darkwebleak_api: {err}")

--- a/ipqualityscore_consts.py
+++ b/ipqualityscore_consts.py
@@ -15,14 +15,13 @@
 
 IPQUALITYSCORE_DOMAIN = "https://ipqualityscore.com"
 
-IPQUALITYSCORE_API_TEST = "https://ipqualityscore.com/api/json/ip/{apikey}/8.8.8.8"
-IPQUALITYSCORE_API_URL_CHECKER = "https://ipqualityscore.com/api/json/url/{apikey}/{url}"
-IPQUALITYSCORE_API_IP_REPUTATION = "https://ipqualityscore.com/api/json/ip/{apikey}/{ip}"
-IPQUALITYSCORE_API_EMAIL_VALIDATION = "https://ipqualityscore.com/api/json/email/{apikey}/{email}"
-IPQUALITYSCORE_API_PHONE_VALIDATION = "https://ipqualityscore.com/api/json/phone/{apikey}/{phone}"
-IPQUALITYSCORE_API_DARKWEBLEAK = "https://ipqualityscore.com/api/json/leaked/{type}/{apikey}/{data}"
+IPQUALITYSCORE_API_TEST = "https://ipqualityscore.com/api/json/ip/8.8.8.8"
+IPQUALITYSCORE_API_URL_CHECKER = "https://ipqualityscore.com/api/json/url/{url}"
+IPQUALITYSCORE_API_IP_REPUTATION = "https://ipqualityscore.com/api/json/ip/{ip}"
+IPQUALITYSCORE_API_EMAIL_VALIDATION = "https://ipqualityscore.com/api/json/email/{email}"
+IPQUALITYSCORE_API_PHONE_VALIDATION = "https://ipqualityscore.com/api/json/phone/{phone}"
+IPQUALITYSCORE_API_DARKWEBLEAK = "https://ipqualityscore.com/api/json/leaked/{type}/{data}"
 
-IPQUALITYSCORE_APP_KEY = "app_key"
 IPQUALITYSCORE_MESSAGE_QUERY_URL = "Querying URL: {query_url}"
 IPQUALITYSCORE_MESSAGE_CONNECTIVITY = "Polling IPQualityScore site ..."
 IPQUALITYSCORE_SERVICE_SUCCESS_MESSAGE = "IPQualityScore Service successfully executed."

--- a/ipqualityscore_consts.py
+++ b/ipqualityscore_consts.py
@@ -1,6 +1,6 @@
 # File: ipqualityscore_consts.py
 #
-# Copyright (c) 2021-2025 IPQualityScore.com
+# Copyright (c) 2021-2026 IPQualityScore.com
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Keep API keys out of request URLs and debug logs by using the IPQS-KEY header


### PR DESCRIPTION
## Summary\n\n- authenticate IPQualityScore requests with the supported IPQS-KEY header\n- remove API keys from request paths and debug-visible URLs\n- update connector development tooling and generated artifacts\n\n## Tracking\n\n- Parent: PAPP-38214\n- Finding: PSAAS-30967\n- Epic: ESPM-5228\n\n## Quality gate\n\n- Local pre-commit: passed\n- Hosted pre-commit and compile: pending\n\nCreated entirely with AI assistance.\n\nWritten by Codex.

## Tracking

- PAPP: PAPP-38214
- PSAAS: PSAAS-30967
- Written by Codex.